### PR TITLE
Update to compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ actix-web = "4"
 crates_io_api = "0.8.1"
 awc = { version = "3.0.1", features = [ "rustls"] }
 sha256 = { version = "1.0.3" }
-sigstore = { version = "0.4.0" }
+sigstore = { version = "0.5", default-features = false  }
 url = "2.1.0"
-opa-client = { path = "../opa-client"}
+opa-client = { git = "https://github.com/seedwing-io/opa-client" }
 serde = "1.0.145"
 serde_json = "1.0.85"
 toml = "0.5.9"

--- a/src/config/repositories.rs
+++ b/src/config/repositories.rs
@@ -3,18 +3,12 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use url::Url;
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct Repositories(IndexMap<String, RepositoryConfig>);
 
 impl Repositories {
     pub fn iter(&self) -> impl Iterator<Item = (&String, &RepositoryConfig)> {
         self.0.iter()
-    }
-}
-
-impl Default for Repositories {
-    fn default() -> Self {
-        Self(Default::default())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,7 @@ async fn main() -> std::io::Result<()> {
 
     let config_toml: PathBuf = matches.get_one("config").cloned().unwrap_or_else(|| {
         if let Ok(pwd) = std::env::current_dir() {
-            let config_toml = pwd.join(DEFAULT_CONFIG);
-            config_toml
+            pwd.join(DEFAULT_CONFIG)
         } else {
             PathBuf::new().join(DEFAULT_CONFIG)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use opa_client::http::OpenPolicyAgentHttpClient;
+
 use crate::cli::cli;
 use crate::config::Config;
 use crate::proxy::Proxy;
@@ -43,7 +45,7 @@ async fn main() -> std::io::Result<()> {
     if let Ok(config_toml) = File::open(config_toml.clone()) {
         match Config::new(config_toml, bind, port) {
             Ok(config) => {
-                let proxy = Proxy::new(config);
+                let proxy: Proxy<OpenPolicyAgentHttpClient> = Proxy::new(config);
                 proxy.run().await
             }
             Err(err) => {

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -3,7 +3,6 @@ use opa_client::{Data, OpenPolicyAgentClient};
 use crate::config::policy::PolicyConfig;
 use crate::policy::context::Context;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use url::Url;
 
 pub mod context;
 
@@ -22,8 +21,8 @@ impl Default for Decision {
 }
 
 pub struct ExplainedDecision {
-    decision: Decision,
-    audit: String,
+    _decision: Decision,
+    _audit: String,
 }
 
 #[derive(Deserialize)]

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -10,13 +10,13 @@ use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct ProxyState<T: OpenPolicyAgentClient> {
-    policy: Arc<PolicyEngine<T>>,
+    _policy: Arc<PolicyEngine<T>>,
 }
 
 impl<T: OpenPolicyAgentClient> ProxyState<T> {
     pub fn new(policy: PolicyEngine<T>) -> Self {
         Self {
-            policy: Arc::new(policy),
+            _policy: Arc::new(policy),
         }
     }
 }

--- a/src/repositories/crates/api/v1/mod.rs
+++ b/src/repositories/crates/api/v1/mod.rs
@@ -22,7 +22,9 @@ async fn download(
             let client = awc::Client::default();
             if let Ok(mut response) = client.get(format!("https://crates.io/{link}")).send().await {
                 if let Ok(payload) = response.body().limit(20_000_000).await {
-                    let digest = sha256::digest_bytes(&payload);
+                    let digest = sha256::digest(
+                        std::str::from_utf8(&payload).expect("could not parse Bytes"),
+                    );
 
                     let query = SearchIndex {
                         email: None,

--- a/src/repositories/crates/mod.rs
+++ b/src/repositories/crates/mod.rs
@@ -8,6 +8,12 @@ pub struct CratesState {
     client: AsyncClient,
 }
 
+impl Default for CratesState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CratesState {
     pub fn new() -> Self {
         let client = AsyncClient::new(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,7 +1,6 @@
 use crate::Config;
 use actix_web::dev::HttpServiceFactory;
-use actix_web::{get, web, App, HttpResponse, Responder};
-use awc::http::StatusCode;
+use actix_web::{get, web, HttpResponse, Responder};
 use handlebars::Handlebars;
 use serde_json::json;
 


### PR DESCRIPTION
This seems to have gotten out of sync with `opa-client`, notably the fact that `OpenPolicyAgentClient` is no longer a struct but now a trait. This PR brings in new changes from `opa-client`.

Note 1: The `opa-client` dependency should not be pinned to my branch, but to the main branch. I will update this if the [corresponding PR](https://github.com/seedwing-io/opa-client/pull/8) is merged.

Note 2: I placed a `dummy` struct in `PolicyEngine::evaluate()` just as a placeholder to have a parameter for  the new `query()` function signature. This should become something more reasonable and I can update it if there are any suggestions.