### PR TITLE
Maven mirror

### DIFF
--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -68,7 +68,7 @@ where
             for service in self.config.repositories().iter().map(|(scope, config)| {
                 match config.repository_type() {
                     RepositoryType::Crates => repositories::crates::service(scope),
-                    RepositoryType::M2 => repositories::maven::service(scope),
+                    RepositoryType::M2 => repositories::maven::service(scope, config.url()),
                 }
             }) {
                 app = app.service(service)

--- a/src/repositories/crates/api/v1/mod.rs
+++ b/src/repositories/crates/api/v1/mod.rs
@@ -1,10 +1,8 @@
 use crate::repositories::crates::CratesState;
+use crate::sigstore::search;
 use actix_web::dev::HttpServiceFactory;
 use actix_web::{get, web, HttpResponse, Responder};
 use awc::http::header;
-use sigstore::rekor::apis::configuration::Configuration;
-use sigstore::rekor::apis::{entries_api, index_api};
-use sigstore::rekor::models::SearchIndex;
 
 #[get("/{version}/download")]
 async fn download(
@@ -21,41 +19,18 @@ async fn download(
             let link = &crate_version.dl_path;
 
             let client = awc::Client::default();
-            if let Ok(mut response) = client.get(format!("https://crates.io/{link}")).send().await {
-                if let Ok(payload) = response.body().limit(20_000_000).await {
+            if let Ok(mut upstream) = client.get(format!("https://crates.io/{link}")).send().await {
+                if let Ok(payload) = upstream.body().limit(20_000_000).await {
                     let digest = sha256::digest(
                         std::str::from_utf8(&payload).expect("could not parse Bytes"),
                     );
-
-                    let query = SearchIndex {
-                        email: None,
-                        public_key: None,
-                        hash: Some(digest.clone()),
-                    };
-
-                    let configuration = Configuration::default();
-
-                    let uuid_vec = index_api::search_index(&configuration, query).await;
-
-                    println!("{crate_name} {version} = {digest} {:?}", uuid_vec);
-
-                    if let Ok(uuid_vec) = uuid_vec {
-                        for uuid in uuid_vec.iter() {
-                            let entry =
-                                entries_api::get_log_entry_by_uuid(&configuration, uuid).await;
-                            if let Ok(entry) = entry {
-                                println!("{:?}", entry);
-                            }
-                        }
-                    }
-
-                    let content_type = response.headers().get(header::CONTENT_TYPE);
+                    let uuids = search(digest.clone()).await;
+                    println!("{crate_name} {version} = {digest} {:?}", uuids);
 
                     let mut response = HttpResponse::Ok();
-                    if let Some(content_type) = content_type {
-                        response.append_header((header::CONTENT_TYPE, content_type));
+                    if let Some(v) = upstream.headers().get(header::CONTENT_TYPE) {
+                        response.append_header((header::CONTENT_TYPE, v));
                     }
-
                     let disposition =
                         format!("attachment; filename=\"{crate_name}-{version}.crate\"");
                     response.append_header((header::CONTENT_DISPOSITION, disposition));

--- a/src/repositories/maven/mod.rs
+++ b/src/repositories/maven/mod.rs
@@ -38,7 +38,7 @@ async fn proxy(
     payload: web::Payload,
     state: web::Data<MavenState>,
 ) -> impl Responder {
-    log::info!("incoming {:?}", req);
+    log::debug!("incoming {:?}", req);
     let uri = format!(
         "{}{}",
         state.url,

--- a/src/repositories/maven/mod.rs
+++ b/src/repositories/maven/mod.rs
@@ -1,10 +1,66 @@
-use actix_web::{get, web, Responder, Scope};
+use actix_web::{route, web, HttpRequest, HttpResponse, HttpResponseBuilder, Responder, Scope};
+use awc::Client;
+use url::Url;
 
-pub fn service(scope: &str) -> Scope {
-    web::scope(&format!("{scope}/")).service(nothing)
+pub struct MavenState {
+    client: Client,
+    url: Url,
+    scope: String,
 }
 
-#[get("/")]
-async fn nothing() -> impl Responder {
-    actix_web::HttpResponse::NotFound().body("not found")
+impl Default for MavenState {
+    fn default() -> Self {
+        Self::new(
+            "https://repo.maven.apache.org/maven2".try_into().unwrap(),
+            "/m2",
+        )
+    }
+}
+
+impl MavenState {
+    pub fn new(url: Url, scope: &str) -> Self {
+        let client = Client::default();
+        let scope = scope.to_string();
+        Self { client, url, scope }
+    }
+}
+
+pub fn service(scope: &str, url: Url) -> Scope {
+    log::info!("scope: {}", scope);
+    web::scope(scope)
+        .app_data(web::Data::new(MavenState::new(url, scope)))
+        .service(proxy)
+}
+
+#[route("{tail:.*}", method = "GET", method = "HEAD")]
+async fn proxy(
+    req: HttpRequest,
+    payload: web::Payload,
+    state: web::Data<MavenState>,
+) -> impl Responder {
+    log::info!("incoming {:?}", req);
+    let uri = format!(
+        "{}{}",
+        state.url,
+        req.uri()
+            .path_and_query()
+            .unwrap()
+            .as_str()
+            .strip_prefix(&format!("/{}", state.scope))
+            .unwrap()
+    );
+    let request = state.client.request_from(uri, req.head());
+    match request.send_stream(payload).await {
+        Ok(upstream) => {
+            let mut response = HttpResponseBuilder::new(upstream.status());
+            for header in upstream.headers().iter() {
+                response.insert_header(header);
+            }
+            response.streaming(upstream)
+        }
+        Err(e) => {
+            log::error!("proxy error: {}", e);
+            HttpResponse::NotFound().body("not found")
+        }
+    }
 }

--- a/src/sigstore/mod.rs
+++ b/src/sigstore/mod.rs
@@ -1,1 +1,30 @@
+use sigstore::rekor::apis::{
+    configuration::Configuration,
+    entries_api::get_log_entry_by_uuid,
+    index_api::{search_index, SearchIndexError},
+    Error,
+};
+use sigstore::rekor::models::SearchIndex;
 
+pub async fn search(digest: String) -> Result<Vec<String>, Error<SearchIndexError>> {
+    let query = SearchIndex {
+        email: None,
+        public_key: None,
+        hash: Some(digest),
+    };
+    let configuration = Configuration::default();
+    match search_index(&configuration, query).await {
+        Ok(uuids) => {
+            if log::log_enabled!(log::Level::Debug) {
+                for uuid in uuids.iter() {
+                    let entry = get_log_entry_by_uuid(&configuration, uuid).await;
+                    if let Ok(entry) = entry {
+                        log::debug!("{:?}", entry);
+                    }
+                }
+            }
+            Ok(uuids)
+        }
+        Err(e) => Err(e),
+    }
+}


### PR DESCRIPTION
Related to #3 

Proxy can be configured as a Maven repo mirror. Currently passes all requests upstream. Integration with -policy will come in a separate PR.

Also includes minor sigstore refactoring in the Crates module.


