### PR TITLE
WIP download a crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ indexmap = { version = "1.9.1", features = [ "serde"] }
 clap = { version = "4.0.8", features = [ "derive"] }
 log = "0.4.17"
 env_logger = "0.9.1"
+reqwest = "0.11.13"
 
 handlebars = "4.3.4"

--- a/seedwing.toml
+++ b/seedwing.toml
@@ -9,7 +9,8 @@ default = "allow"
 
 [repositories.crates-io]
 type = "crates"
-url = "https://crates.io/"
+#url = "https://crates.io/"
+url = "https://github.com/rust-lang/crates.io-index"
 
 [repositories.m2]
 type = "m2"

--- a/seedwing.toml
+++ b/seedwing.toml
@@ -9,9 +9,10 @@ default = "allow"
 
 [repositories.crates-io]
 type = "crates"
-#url = "https://crates.io/"
 url = "https://github.com/rust-lang/crates.io-index"
+default = true
 
 [repositories.m2]
 type = "m2"
 url = "https://repo.maven.apache.org/maven2"
+default = false

--- a/src/config/repositories.rs
+++ b/src/config/repositories.rs
@@ -38,6 +38,7 @@ pub struct RepositoryConfig {
     #[serde(rename = "type")]
     repository_type: RepositoryType,
     url: Url,
+    default: bool
 }
 
 impl RepositoryConfig {
@@ -47,5 +48,9 @@ impl RepositoryConfig {
 
     pub fn url(&self) -> Url {
         self.url.clone()
+    }
+
+    pub fn default(&self) -> bool {
+        self.default
     }
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -67,7 +67,7 @@ where
 
             for service in self.config.repositories().iter().map(|(scope, config)| {
                 match config.repository_type() {
-                    RepositoryType::Crates => repositories::crates::service(scope),
+                    RepositoryType::Crates => repositories::crates::service(scope, config.url()),
                     RepositoryType::M2 => repositories::maven::service(scope),
                 }
             }) {

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -79,6 +79,6 @@ where
 
         log::info!("seedwing at http://{}:{}/", bind_args.0, bind_args.1);
         log::info!("========================================================================");
-        server.bind(bind_args)?.run().await
+        server.workers(1).bind(bind_args)?.run().await
     }
 }

--- a/src/repositories/crates/api/mod.rs
+++ b/src/repositories/crates/api/mod.rs
@@ -1,1 +1,60 @@
+use crate::repositories::crates::CratesState;
+use actix_web::dev::{HttpServiceFactory,PeerAddr};
+use actix_web::{error, web, Error, HttpRequest, HttpResponse};
+
 pub mod v1;
+
+// Mostly copied from actix http-proxy example code
+
+async fn forward(
+    req: HttpRequest,
+    payload: web::Payload,
+    peer_addr: Option<PeerAddr>,
+    crates: web::Data<CratesState>,
+) -> Result<HttpResponse, Error> {
+    log::info!("forward url: {}, path: {:?}", crates.url, req.path());
+
+    let mut repo_url = crates.url.clone();
+    let req_path = req.uri().path();
+    let repo_path = repo_url.path();
+
+    let scope = crates.scope.as_str();
+    let new_path = format!("{repo_path}{}", req_path.strip_prefix(scope).unwrap());
+
+    log::info!("Forwarding uri: {req_path} in scope {scope}");
+    repo_url.set_path(new_path.as_str());
+    repo_url.set_query(req.uri().query());
+
+    log::info!("Forwarding request to: {repo_url}");
+    let forwarded_req = crates.awc
+        .request_from(repo_url.as_str(), req.head())
+        .no_decompress();
+
+    // TODO: This forwarded implementation is incomplete as it only handles the unofficial
+    // X-Forwarded-For header but not the official Forwarded one.
+    let forwarded_req = match peer_addr {
+        Some(PeerAddr(addr)) => {
+            forwarded_req.insert_header(("x-forwarded-for", addr.ip().to_string()))
+        }
+        None => forwarded_req,
+    };
+
+    let res = forwarded_req
+        .send_stream(payload)
+        .await
+        .map_err(error::ErrorInternalServerError)?;
+
+    let mut client_resp = HttpResponse::build(res.status());
+    // Remove `Connection` as per
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection#Directives
+    for (header_name, header_value) in res.headers().iter().filter(|(h, _)| *h != "connection") {
+        client_resp.insert_header((header_name.clone(), header_value.clone()));
+    }
+
+    Ok(client_resp.streaming(res))
+}
+
+pub fn proxy_service(scope: &str) -> impl HttpServiceFactory {
+    log::info!("{scope}");
+    web::resource(scope).to(forward)
+}

--- a/src/repositories/crates/api/mod.rs
+++ b/src/repositories/crates/api/mod.rs
@@ -1,11 +1,12 @@
 use crate::repositories::crates::CratesState;
 use actix_web::dev::{HttpServiceFactory,PeerAddr};
-use actix_web::{error, web, Error, HttpRequest, HttpResponse};
+use actix_web::{get, error, web, Error, HttpRequest, HttpResponse};
 
 pub mod v1;
 
 // Mostly copied from actix http-proxy example code
 
+//#[get("/other")]
 async fn forward(
     req: HttpRequest,
     payload: web::Payload,
@@ -55,6 +56,6 @@ async fn forward(
 }
 
 pub fn proxy_service(scope: &str) -> impl HttpServiceFactory {
-    log::info!("{scope}");
+    log::info!("scope is: {scope}");
     web::resource(scope).to(forward)
 }

--- a/src/repositories/crates/api/mod.rs
+++ b/src/repositories/crates/api/mod.rs
@@ -6,7 +6,6 @@ pub mod v1;
 
 // Mostly copied from actix http-proxy example code
 
-//#[get("/other")]
 async fn forward(
     req: HttpRequest,
     payload: web::Payload,

--- a/src/repositories/crates/api/v1/mod.rs
+++ b/src/repositories/crates/api/v1/mod.rs
@@ -93,7 +93,7 @@ pub fn modify_index() {
     //let mut file = std::fs::File::create(file_path)
     //    .expect("could not create config.json");
     
-    std::fs::write(path, "{\n\"dl\": \"http://localhost:8181/api/v1/crates\",\n\"api\": \"https://crates.io\"\n}")
+    std::fs::write(path, "{\n\t\"dl\": \"http://localhost:8181/api/v1/crates\",\n\t\"api\": \"http://localhost:8181\"\n}")
         .expect("could not write to config.json");
 
     log::info!("succeeded modifying index");

--- a/src/repositories/crates/api/v1/mod.rs
+++ b/src/repositories/crates/api/v1/mod.rs
@@ -92,10 +92,7 @@ pub fn modify_index() {
 
     let path = path.join("crates.io-index/config.json");
     log::info!("file path: {:?}", path);
-
-    //let mut file = std::fs::File::create(file_path)
-    //    .expect("could not create config.json");
-    
+ 
     std::fs::write(path, "{\n\t\"dl\": \"http://localhost:8181/api/v1/crates\",\n\t\"api\": \"https://crates.io\"\n}")
         .expect("could not write to config.json");
 
@@ -106,8 +103,6 @@ pub fn service() -> impl HttpServiceFactory {
     log::info!("inside crates service");
 
     modify_index();
-
-    //web::resource(scope).to(forward)
 
     web::scope("/crates/{crate_name}").service(download)
 }

--- a/src/repositories/crates/mod.rs
+++ b/src/repositories/crates/mod.rs
@@ -1,32 +1,43 @@
 use actix_web::{web, Scope};
 use crates_io_api::AsyncClient;
+use url::Url;
+use awc::Client;
 
 pub mod api;
 
 pub struct CratesState {
     client: AsyncClient,
+    scope: String,
+    url: Url,
+    awc: Client,
 }
 
 impl Default for CratesState {
     fn default() -> Self {
-        Self::new()
+        Self::new("/crates-io", Url::parse("https://crates.io/").expect("Could not parse default URL"))
     }
 }
 
 impl CratesState {
-    pub fn new() -> Self {
+    pub fn new(scope: &str, url: Url) -> Self {
         let client = AsyncClient::new(
             "seedwing-io (bmcwhirt@redhat.com)",
             std::time::Duration::from_millis(1000),
         )
         .expect("Unable to construct crates.io async client");
 
-        Self { client }
+        let awc = Client::default();
+        let scope = String::from(scope);
+        Self { client, scope, url, awc }
     }
 }
 
-pub fn service(scope: &str) -> Scope {
-    web::scope(&format!("{scope}/api/v1"))
-        .app_data(web::Data::new(CratesState::new()))
-        .service(api::v1::service())
+pub fn service(scope: &str, url: Url) -> Scope {
+    let scope = format!("/{scope}");
+    log::info!("Creating cargo service with scope {scope} and url {url}");
+    web::scope(&scope)
+        .app_data(web::Data::new(CratesState::new(&scope, url)))
+        .service(web::scope("/api/v1").service(api::v1::service()))
+        .service(api::proxy_service("/info/refs"))
+        .service(api::proxy_service("/git-upload-pack"))
 }

--- a/src/repositories/crates/mod.rs
+++ b/src/repositories/crates/mod.rs
@@ -1,4 +1,5 @@
 use actix_web::{web, Scope};
+use actix_web::dev::HttpServiceFactory;
 use crates_io_api::AsyncClient;
 use url::Url;
 use awc::Client;
@@ -32,6 +33,7 @@ impl CratesState {
     }
 }
 
+// proxy run() sends to here
 pub fn service(scope: &str, url: Url/*, crate_name: &str, crate_version: &str*/) -> Scope {
     let scope = format!("/{scope}");
     log::info!("Creating cargo service with scope {scope} and url {url}");
@@ -40,6 +42,4 @@ pub fn service(scope: &str, url: Url/*, crate_name: &str, crate_version: &str*/)
         .service(web::scope("/api/v1").service(api::v1::service()))
         .service(api::proxy_service("/info/refs"))
         .service(api::proxy_service("/git-upload-pack"))
-        //.default_service(api::proxy_service("/other"))
-        //.service(api::proxy_service("/api/v1/crates/{}/{}/download", crate_name, crate_version))
 }

--- a/src/repositories/crates/mod.rs
+++ b/src/repositories/crates/mod.rs
@@ -32,7 +32,7 @@ impl CratesState {
     }
 }
 
-pub fn service(scope: &str, url: Url) -> Scope {
+pub fn service(scope: &str, url: Url/*, crate_name: &str, crate_version: &str*/) -> Scope {
     let scope = format!("/{scope}");
     log::info!("Creating cargo service with scope {scope} and url {url}");
     web::scope(&scope)
@@ -40,4 +40,6 @@ pub fn service(scope: &str, url: Url) -> Scope {
         .service(web::scope("/api/v1").service(api::v1::service()))
         .service(api::proxy_service("/info/refs"))
         .service(api::proxy_service("/git-upload-pack"))
+        //.default_service(api::proxy_service("/other"))
+        //.service(api::proxy_service("/api/v1/crates/{}/{}/download", crate_name, crate_version))
 }

--- a/src/repositories/mod.rs
+++ b/src/repositories/mod.rs
@@ -1,2 +1,4 @@
 pub mod crates;
 pub mod maven;
+
+

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,6 +12,8 @@ const INDEX: &str = include_str!("index.html");
 
 #[get("/")]
 async fn index(config: web::Data<UiState>) -> impl Responder {
+    log::info!("in the ui index\n\n");
+
     let index = Handlebars::new();
 
     let result = index.render_template(


### PR DESCRIPTION
Will be thoroughly cleaned up, but takes the following steps:

1. git clones crates-io index and modifies `dl` link to point to proxy
2. handles default GET requests by pointing them to `https://crates.io` instead of the localhost

The crate downloads but the checksum does not yet pass.

I will also drop the commits I was building on top of.