### PR TITLE
Replace 'default' config with 'decision' 

### DIFF
--- a/seedwing.toml
+++ b/seedwing.toml
@@ -4,7 +4,7 @@ port = 8181
 
 [policy]
 url = 'http://localhost:8080/policy/proxy/context'
-default = "deny"
+decision = "disable"            # disable | warn | enforce
 
 [repositories.crates-io]
 type = "crates"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -108,16 +108,16 @@ mod test {
             Url::parse("http://localhost:8080/").unwrap(),
             config.policy.url()
         );
-        assert_eq!(Decision::Deny, config.policy.default_decision());
+        assert_eq!(Decision::Disable, config.policy.decision());
     }
 
     #[test]
-    fn basic_config_default_allow() {
+    fn basic_config_default_warn() {
         let config: Config = toml::from_str(
             r#"
             [policy]
             url = 'http://localhost:8080/'
-            default = "allow"
+            decision = "warn"
         "#,
         )
         .unwrap();
@@ -128,7 +128,7 @@ mod test {
             Url::parse("http://localhost:8080/").unwrap(),
             config.policy.url()
         );
-        assert_eq!(Decision::Allow, config.policy.default_decision());
+        assert_eq!(Decision::Warn, config.policy.decision());
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod test {
 
             [policy]
             url = 'http://localhost:8080/'
-            enforce = false
+            decision = "enforce"
 
             [repositories.crates-io]
             type = "crates"
@@ -160,7 +160,7 @@ mod test {
             Url::parse("http://localhost:8080/").unwrap(),
             config.policy.url()
         );
-        assert_eq!(Decision::Deny, config.policy.default_decision());
+        assert_eq!(Decision::Enforce, config.policy.decision());
 
         let mut repo_iter = config.repositories.iter();
 

--- a/src/config/policy.rs
+++ b/src/config/policy.rs
@@ -4,14 +4,14 @@ use url::Url;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PolicyConfig {
-    #[serde(rename = "default", default)]
-    default_decision: Decision,
+    #[serde(default)]
+    decision: Decision,
     url: Url,
 }
 
 impl PolicyConfig {
-    pub fn default_decision(&self) -> Decision {
-        self.default_decision
+    pub fn decision(&self) -> Decision {
+        self.decision
     }
 
     pub fn url(&self) -> Url {


### PR DESCRIPTION
Fixes #19 

Still not sure about 'decision' for a name, but 'policy' seemed redundant inside the [policy] section, and the enum itself was already called 'Decision' so I went with it.

Valid values are [disable|warn|enforce] but those are subject to change as well.

Signed-off-by: Jim Crossley <jim@crossleys.org>