### PR TITLE
feat: fully construct PURL in Context struct to be evaluated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4.17"
 env_logger = "0.9.1"
 home = "0.5.4"
 handlebars = "4.3.4"
-
+urlencoding = "2.1.2"
 fs2 = "0.4.3"
 git2 = "0.16.1"
 thiserror = "1.0.38"

--- a/src/policy/context.rs
+++ b/src/policy/context.rs
@@ -5,45 +5,16 @@ pub struct Context {
     purl: String,
     url: String,
     hash: String,
-    id: ArtifactIdentifier,
-    license: Option<String>,
-    repository_id: String,
 }
 
 impl Context {
-    pub fn new(
-        purl: String,
-        url: String,
-        hash: String,
-        id: ArtifactIdentifier,
-        repository_id: String,
-    ) -> Context {
-        let license = None; // TODO: something
-        Context {
-            purl,
-            url,
-            hash,
-            id,
-            license,
-            repository_id,
-        }
+    pub fn new(purl: String, url: String, hash: String) -> Context {
+        Context { purl, url, hash }
     }
 
     pub fn url(&self) -> &str {
         &self.url
     }
-}
-
-#[derive(Serialize)]
-#[serde(tag = "_type")]
-pub enum ArtifactIdentifier {
-    #[serde(rename = "crate")]
-    Crate { name: String },
-    #[serde(rename = "m2")]
-    M2 {
-        group_id: String,
-        artifact_id: String,
-    },
 }
 
 #[cfg(test)]
@@ -56,11 +27,6 @@ mod test {
             purl: "pkg:cargo/crate@0.1.0".into(),
             url: "http://crates.io/not/a/real/crate.crate".into(),
             hash: "8675309".into(),
-            id: ArtifactIdentifier::Crate {
-                name: "rust_crate".into(),
-            },
-            license: None,
-            repository_id: "crates-io".to_string(),
         };
 
         let json = serde_json::to_string(&context).unwrap();

--- a/src/repositories/crates/api/v1/mod.rs
+++ b/src/repositories/crates/api/v1/mod.rs
@@ -1,8 +1,5 @@
 use crate::errors::Result;
-use crate::policy::{
-    context::{ArtifactIdentifier, Context},
-    PolicyEngine,
-};
+use crate::policy::{context::Context, PolicyEngine};
 use crate::repositories::crates::CratesDownloadConfig;
 use actix_web::dev::HttpServiceFactory;
 use actix_web::{get, web, HttpResponse, HttpResponseBuilder, Responder};
@@ -34,15 +31,10 @@ async fn download(
             let mut upstream = policy.client.get(url.clone()).send().await?;
             let payload = upstream.body().limit(20_000_000).await?;
 
-            let id = ArtifactIdentifier::Crate {
-                name: crate_name.clone(),
-            };
             let context = Context::new(
                 format!("pkg:cargo/{crate_name}@{version}"),
                 url,
                 sha256::digest(payload.as_ref()), // todo: double check this
-                id,
-                crates.scope.to_owned(),
             );
 
             match policy.evaluate(&context).await? {

--- a/src/repositories/crates/mod.rs
+++ b/src/repositories/crates/mod.rs
@@ -11,20 +11,17 @@ pub mod git;
 pub mod sparse;
 
 pub struct CratesDownloadConfig {
-    scope: String,
     client: AsyncClient,
 }
 
-impl CratesDownloadConfig {
-    pub fn new(scope: &str) -> Self {
-        let scope = String::from(scope);
+impl Default for CratesDownloadConfig {
+    fn default() -> Self {
         let client = AsyncClient::new(
             "seedwing-io (seedwing@example.com)",
             std::time::Duration::from_millis(1000),
         )
         .expect("Unable to construct crates.io async client");
-
-        Self { scope, client }
+        Self { client }
     }
 }
 
@@ -73,7 +70,7 @@ pub fn service(
     let scope = format!("/{scope}");
     log::info!("Creating cargo service with scope {scope}");
     web::scope(&scope)
-        .app_data(web::Data::new(CratesDownloadConfig::new(&scope)))
+        .app_data(web::Data::new(CratesDownloadConfig::default()))
         .app_data(web::Data::new(CratesConfig::new(
             &scope,
             git_cmd,
@@ -93,7 +90,7 @@ pub fn service_sparse(
     let scope = format!("/{scope}");
     log::info!("Creating cargo sparse service with scope {scope}");
     web::scope(&scope)
-        .app_data(web::Data::new(CratesDownloadConfig::new(&scope)))
+        .app_data(web::Data::new(CratesDownloadConfig::default()))
         .app_data(web::Data::new(CratesSparseConfig::new(
             &scope,
             sparse_repository,


### PR DESCRIPTION
Fixes #32
Fixes #34

The PURL now fully describes the artifact under evaluation, including 'type' and 'repository_url for Maven artifacts.

We no longer pass scope, license or id, since all should be determined from the PURL by the policy engine.